### PR TITLE
Separate Page4 excel path state

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -228,8 +228,6 @@ function App() {
 
         {activePage === 4 && (
           <Page4
-            bomPath={bomPath}
-            setBomPath={setBomPath}
             removeHItems={removeHItems}
             setRemoveHItems={setRemoveHItems}
             removeMirror={removeMirror}

--- a/frontend/src/Page_4/Page4.jsx
+++ b/frontend/src/Page_4/Page4.jsx
@@ -8,7 +8,6 @@ import './Page4.css';
 
 
 const Page4 = ({
-  bomPath, setBomPath,
   removeHItems, setRemoveHItems,
   removeMirror, setRemoveMirror,
   ready2, setReady2,
@@ -27,6 +26,9 @@ const Page4 = ({
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const toggleMenu = () => setIsMenuOpen(prev => !prev);
+
+  // Local state for excel path used only on Page4
+  const [bomPath, setBomPath] = useState('');
 
   
 


### PR DESCRIPTION
## Summary
- make Page4 use its own Excel path state
- remove bomPath props when rendering Page4

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac9d2da44832787ea13f85669c8c9