### PR TITLE
Separate page logic

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { useEffect } from 'react';
 import Page1 from './Page_1/Page1';
 import Page2 from './Page_2/Page2';
 import Page3 from './Page_3/Page3';
@@ -29,142 +28,6 @@ function App() {
 
 
 
-  const resetApp = () => {
-    setBomPath('');
-    setRemoveHItems(false);
-    setRemoveMirror(false);
-    setReady2(false);
-    setReady3(false);
-    setDrawingPath('');
-    setCurrentPhase(1);
-    setStatuses({ phase1: 'idle', phase2: 'idle', phase3: 'idle' });
-    setScore2(" ");
-    setScore3(" ");
-    setComment("Witaj w CreoMate! Wybierz plik BOM i rozpocznij proces.");
-    setExcelButtonColor("#949494");
-  };
-
-  const runPhase = async (phaseKey, url) => {
-    setStatuses(s => ({ ...s, [phaseKey]: 'running' }));
-    let dotCount = 0;
-    setComment("Loading");
-
-    const loadingInterval = setInterval(() => {
-      dotCount = (dotCount + 1) % 4;
-      setComment("Loading" + ".".repeat(dotCount));
-    }, 500);
-
-    setTimeout(async () => {
-      clearInterval(loadingInterval);
-      try {
-        let res = (phaseKey === "phase2")
-          ? await fetch(url, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ removeHItems, removeMirror }),
-          })
-          : await fetch(url);
-
-        const data = await res.json();
-
-        if (phaseKey === "phase1" && data.ready) {
-          setComment("BOM został poprawnie przetworzony i zapisany w Excelu.");
-          setExcelButtonColor("#0066ff");
-        } else if (phaseKey === "phase2" && data.message) {
-          setScore2(data.message);
-          setComment(data.ready ? "Etap 2 zakończony pomyślnie. Możesz przejść do etapu 3." : "Popraw Excel, aby kontynuować.");
-        } else if (phaseKey === "phase3" && data.message) {
-          setScore3(data.message);
-          setComment(data.ready ? "Etap 3 zakończony pomyślnie. Wygeneruj Excel do działu zakupów." : "Sprawdź rysunki, aby kontynuować.");
-        }
-
-        setStatuses(s => ({ ...s, [phaseKey]: data.ready ? 'done' : 'running' }));
-        if (data.ready) setCurrentPhase(p => p < 5 ? p + 1 : p);
-      } catch (err) {
-        setStatuses(s => ({ ...s, [phaseKey]: 'idle' }));
-        alert(`Error running ${phaseKey}: ${err.message}`);
-      }
-    }, 1700);
-  };
-
-  const isExcelOpen = async () => {
-    try {
-      const res = await fetch("http://127.0.0.1:8000/isExcelOpen");
-      const text = await res.text();
-      const data = JSON.parse(text);
-      return data.open;
-    } catch (err) {
-      console.error("Failed to check Excel status:", err);
-      return false;
-    }
-  };
-
-  const handleStart = async () => {
-    let excelOpen = false;
-    if (currentPhase > 1) {
-      excelOpen = await isExcelOpen();
-    }
-
-    if (excelOpen) {
-      setComment("Excel jest już otwarty. Zamknij go!");
-      return;
-    }
-
-    if (drawingPath === "" && currentPhase === 3) {
-      setComment("Wybierz folder z rysunkami!");
-      return;
-    }
-
-    if (bomPath === "" && currentPhase === 1) {
-      setComment("Wybierz plik BOM!");
-      return;
-    }
-
-    const phaseUrls = {
-      1: "http://127.0.0.1:8000/run-phase1",
-      2: "http://127.0.0.1:8000/run-phase2",
-      3: "http://127.0.0.1:8000/run-phase3",
-      4: "http://127.0.0.1:8000/run-phase4",
-      10: "http://127.0.0.1:8000/run-phase10",
-    };
-
-    if (currentPhase >= 1 && currentPhase <= 4) {
-      await runPhase(`phase${currentPhase}`, phaseUrls[currentPhase]);
-    } else if (currentPhase === 5) {
-      resetApp();
-    } else {
-      alert("All phases complete!");
-    }
-  };
-
-  const openExcel = async () => {
-    try {
-      const res = await fetch("http://127.0.0.1:8000/openExcel");
-      const data = await res.json();
-      if (data.ready) console.log("Excel opened successfully.");
-    } catch (err) {
-      console.error("Failed to open Excel:", err);
-    }
-  };
-
-  const openExcelPurchases = async () => {
-    try {
-      const res = await fetch("http://127.0.0.1:8000/openExcelPurchases");
-      const data = await res.json();
-      if (data.ready) console.log("Purchase Excel opened.");
-    } catch (err) {
-      console.error("Failed to open Excel:", err);
-    }
-  };
-
-
-
-  const getButtonLabel = () => {
-    if (currentPhase <= 3) return `Start Etap ${currentPhase}`;
-    if (currentPhase === 4) return "Wygeneruj Gotowy Excel";
-    if (currentPhase === 5) return "Nowy BOM";
-    return "Proces zakończony";
-  };
 
 
 
@@ -196,13 +59,13 @@ function App() {
             statuses={statuses}
             setStatuses={setStatuses}
             score2={score2}
+            setScore2={setScore2}
             score3={score3}
+            setScore3={setScore3}
             comment={comment}
+            setComment={setComment}
             excelButtonColor={excelButtonColor}
-            handleStart={handleStart}
-            getButtonLabel={getButtonLabel}
-            openExcel={openExcel}
-            openExcelPurchases={openExcelPurchases}
+            setExcelButtonColor={setExcelButtonColor}
           />
         )}
 
@@ -214,7 +77,6 @@ function App() {
             setStatuses={setStatuses}
             comment={comment}
             excelButtonColor={excelButtonColor}
-            getButtonLabel={getButtonLabel}
             purchases_Excel={Purchases_Excel}
             setPurchases_Excel={setPurchases_Excel}
             setComment={setComment}
@@ -227,32 +89,7 @@ function App() {
         )}
 
         {activePage === 4 && (
-          <Page4
-            bomPath={bomPath}
-            setBomPath={setBomPath}
-            removeHItems={removeHItems}
-            setRemoveHItems={setRemoveHItems}
-            removeMirror={removeMirror}
-            setRemoveMirror={setRemoveMirror}
-            ready2={ready2}
-            setReady2={setReady2}
-            ready3={ready3}
-            setReady3={setReady3}
-            drawingPath={drawingPath}
-            setDrawingPath={setDrawingPath}
-            currentPhase={currentPhase}
-            setCurrentPhase={setCurrentPhase}
-            statuses={statuses}
-            setStatuses={setStatuses}
-            score2={score2}
-            score3={score3}
-            comment={comment}
-            excelButtonColor={excelButtonColor}
-            handleStart={handleStart}
-            getButtonLabel={getButtonLabel}
-            openExcel={openExcel}
-            openExcelPurchases={openExcelPurchases}
-          />
+          <Page4 />
         )}
       </div>
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -73,7 +73,7 @@ function App() {
           <Page2
             drawingPath={drawingPath}
             setDrawingPath={setDrawingPath}
-            statues={statuses}
+            statuses={statuses}
             setStatuses={setStatuses}
             comment={comment}
             excelButtonColor={excelButtonColor}

--- a/frontend/src/Page_1/P1_components/P1_Step1.jsx
+++ b/frontend/src/Page_1/P1_components/P1_Step1.jsx
@@ -33,7 +33,7 @@ function Step1({ bomPath, setBomPath, status }) {
           <input
             value={bomPath}
             style={{ width: '560px' }}
-            readFOnly
+            readOnly
             id="custom-input"
           />
           <button id="button_folder" onClick={handleChooseFile}>📁</button>

--- a/frontend/src/Page_1/P1_components/P1_Step2.jsx
+++ b/frontend/src/Page_1/P1_components/P1_Step2.jsx
@@ -43,7 +43,7 @@ function Step2({ removeHItems, setRemoveHItems, removeMirror, setRemoveMirror, r
             setStatuses((s) => ({ ...s, phase2: 'idle' }));
             setCurrentPhase(2); // Optional: move back to phase 2
           }
-        }}s
+        }}
       />
       <span className="slider"></span>
     </label>

--- a/frontend/src/Page_1/Page1.jsx
+++ b/frontend/src/Page_1/Page1.jsx
@@ -16,17 +16,157 @@ const Page1 = ({
   drawingPath, setDrawingPath,
   currentPhase,
   statuses, setStatuses,
-  score2, score3,
-  comment,
-  excelButtonColor,
-  handleStart,
-  getButtonLabel,
-  openExcel,
-  openExcelPurchases,
-  setCurrentPhase, // ✅ Only once
+  score2, setScore2,
+  score3, setScore3,
+  comment, setComment,
+  excelButtonColor, setExcelButtonColor,
+  setCurrentPhase,
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const toggleMenu = () => setIsMenuOpen(prev => !prev);
+
+  const resetPage = () => {
+    setBomPath('');
+    setRemoveHItems(false);
+    setRemoveMirror(false);
+    setReady2(false);
+    setReady3(false);
+    setDrawingPath('');
+    setCurrentPhase(1);
+    setStatuses({ phase1: 'idle', phase2: 'idle', phase3: 'idle' });
+    setScore2(' ');
+    setScore3(' ');
+    setComment('Witaj w CreoMate! Wybierz plik BOM i rozpocznij proces.');
+    setExcelButtonColor('#949494');
+  };
+
+  const runPhase = async (phaseKey, url) => {
+    setStatuses(s => ({ ...s, [phaseKey]: 'running' }));
+    let dotCount = 0;
+    setComment('Loading');
+
+    const loadingInterval = setInterval(() => {
+      dotCount = (dotCount + 1) % 4;
+      setComment('Loading' + '.'.repeat(dotCount));
+    }, 500);
+
+    setTimeout(async () => {
+      clearInterval(loadingInterval);
+      try {
+        let res = (phaseKey === 'phase2')
+          ? await fetch(url, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ removeHItems, removeMirror }),
+            })
+          : await fetch(url);
+
+        const data = await res.json();
+
+        if (phaseKey === 'phase1' && data.ready) {
+          setComment('BOM został poprawnie przetworzony i zapisany w Excelu.');
+          setExcelButtonColor('#0066ff');
+        } else if (phaseKey === 'phase2' && data.message) {
+          setScore2(data.message);
+          setComment(
+            data.ready
+              ? 'Etap 2 zakończony pomyślnie. Możesz przejść do etapu 3.'
+              : 'Popraw Excel, aby kontynuować.'
+          );
+        } else if (phaseKey === 'phase3' && data.message) {
+          setScore3(data.message);
+          setComment(
+            data.ready
+              ? 'Etap 3 zakończony pomyślnie. Wygeneruj Excel do działu zakupów.'
+              : 'Sprawdź rysunki, aby kontynuować.'
+          );
+        }
+
+        setStatuses(s => ({ ...s, [phaseKey]: data.ready ? 'done' : 'running' }));
+        if (data.ready) setCurrentPhase(p => (p < 5 ? p + 1 : p));
+      } catch (err) {
+        setStatuses(s => ({ ...s, [phaseKey]: 'idle' }));
+        alert(`Error running ${phaseKey}: ${err.message}`);
+      }
+    }, 1700);
+  };
+
+  const isExcelOpen = async () => {
+    try {
+      const res = await fetch('http://127.0.0.1:8000/isExcelOpen');
+      const text = await res.text();
+      const data = JSON.parse(text);
+      return data.open;
+    } catch (err) {
+      console.error('Failed to check Excel status:', err);
+      return false;
+    }
+  };
+
+  const handleStart = async () => {
+    let excelOpen = false;
+    if (currentPhase > 1) {
+      excelOpen = await isExcelOpen();
+    }
+
+    if (excelOpen) {
+      setComment('Excel jest już otwarty. Zamknij go!');
+      return;
+    }
+
+    if (drawingPath === '' && currentPhase === 3) {
+      setComment('Wybierz folder z rysunkami!');
+      return;
+    }
+
+    if (bomPath === '' && currentPhase === 1) {
+      setComment('Wybierz plik BOM!');
+      return;
+    }
+
+    const phaseUrls = {
+      1: 'http://127.0.0.1:8000/run-phase1',
+      2: 'http://127.0.0.1:8000/run-phase2',
+      3: 'http://127.0.0.1:8000/run-phase3',
+      4: 'http://127.0.0.1:8000/run-phase4',
+      10: 'http://127.0.0.1:8000/run-phase10',
+    };
+
+    if (currentPhase >= 1 && currentPhase <= 4) {
+      await runPhase(`phase${currentPhase}`, phaseUrls[currentPhase]);
+    } else if (currentPhase === 5) {
+      resetPage();
+    } else {
+      alert('All phases complete!');
+    }
+  };
+
+  const openExcel = async () => {
+    try {
+      const res = await fetch('http://127.0.0.1:8000/openExcel');
+      const data = await res.json();
+      if (data.ready) console.log('Excel opened successfully.');
+    } catch (err) {
+      console.error('Failed to open Excel:', err);
+    }
+  };
+
+  const openExcelPurchases = async () => {
+    try {
+      const res = await fetch('http://127.0.0.1:8000/openExcelPurchases');
+      const data = await res.json();
+      if (data.ready) console.log('Purchase Excel opened.');
+    } catch (err) {
+      console.error('Failed to open Excel:', err);
+    }
+  };
+
+  const getButtonLabel = () => {
+    if (currentPhase <= 3) return `Start Etap ${currentPhase}`;
+    if (currentPhase === 4) return 'Wygeneruj Gotowy Excel';
+    if (currentPhase === 5) return 'Nowy BOM';
+    return 'Proces zakończony';
+  };
 
   
 

--- a/frontend/src/Page_2/P2_components/P2_Step1.jsx
+++ b/frontend/src/Page_2/P2_components/P2_Step1.jsx
@@ -20,7 +20,7 @@ function Step1({ purchases_Excel, setPurchases_Excel, score_Excel }) {
           <input
             value={purchases_Excel}
             style={{ width: '560px' }}
-            readFOnly
+            readOnly
             id="custom-input"
           />
           <button id="button_folder" onClick={handleChooseFile}>📁</button>

--- a/frontend/src/Page_2/Page2.jsx
+++ b/frontend/src/Page_2/Page2.jsx
@@ -14,10 +14,9 @@ const Page2 = ({
   drawingPath, setDrawingPath,
   currentPhase,
   statuses, setStatuses,
-  comment, setComment, 
+  comment, setComment,
   excelButtonColor,
-  getButtonLabel,
-  purchases_Excel, 
+  purchases_Excel,
   setPurchases_Excel,
   setExcelButtonColor
 }) => {

--- a/frontend/src/Page_2/Page2.jsx
+++ b/frontend/src/Page_2/Page2.jsx
@@ -139,7 +139,7 @@ const openExcelPurchases_Zakupy = async () => {
               drawingPath={drawingPath}
               setDrawingPath={setDrawingPath}
 
-              score_drowings = {score_drowings}
+              score_drowings={score_drowings}
             />
           </div>
         </div>

--- a/frontend/src/Page_4/P1_components/P1_Step1.jsx
+++ b/frontend/src/Page_4/P1_components/P1_Step1.jsx
@@ -33,7 +33,7 @@ function Step1({ bomPath, setBomPath, status }) {
           <input
             value={bomPath}
             style={{ width: '560px' }}
-            readFOnly
+            readOnly
             id="custom-input"
           />
           <button id="button_folder" onClick={handleChooseFile}>📁</button>

--- a/frontend/src/Page_4/P1_components/P1_Step2.jsx
+++ b/frontend/src/Page_4/P1_components/P1_Step2.jsx
@@ -43,7 +43,7 @@ function Step2({ removeHItems, setRemoveHItems, removeMirror, setRemoveMirror, r
             setStatuses((s) => ({ ...s, phase2: 'idle' }));
             setCurrentPhase(2); // Optional: move back to phase 2
           }
-        }}s
+        }}
       />
       <span className="slider"></span>
     </label>

--- a/frontend/src/Page_4/Page4.jsx
+++ b/frontend/src/Page_4/Page4.jsx
@@ -7,26 +7,172 @@ import './Page4.css';
 
 
 
-const Page4 = ({
-  bomPath, setBomPath,
-  removeHItems, setRemoveHItems,
-  removeMirror, setRemoveMirror,
-  ready2, setReady2,
-  ready3, setReady3,
-  drawingPath, setDrawingPath,
-  currentPhase,
-  statuses, setStatuses,
-  score2, score3,
-  comment,
-  excelButtonColor,
-  handleStart,
-  getButtonLabel,
-  openExcel,
-  openExcelPurchases,
-  setCurrentPhase, // ✅ Only once
-}) => {
+const Page4 = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const toggleMenu = () => setIsMenuOpen(prev => !prev);
+
+  // Local state for excel path used only on Page4
+  const [bomPath, setBomPath] = useState('');
+
+  // Localised state copied from App for independent use on Page4
+  const [removeHItems, setRemoveHItems] = useState(false);
+  const [removeMirror, setRemoveMirror] = useState(false);
+  const [ready2, setReady2] = useState(false);
+  const [ready3, setReady3] = useState(false);
+  const [drawingPath, setDrawingPath] = useState('');
+  const [currentPhase, setCurrentPhase] = useState(1);
+  const [statuses, setStatuses] = useState({
+    phase1: 'idle',
+    phase2: 'idle',
+    phase3: 'idle',
+  });
+  const [score2, setScore2] = useState(' ');
+  const [score3, setScore3] = useState(' ');
+  const [comment, setComment] = useState('Witaj w CreoMate! Wybierz plik BOM i rozpocznij proces.');
+  const [excelButtonColor, setExcelButtonColor] = useState('#949494');
+
+  const resetLocal = () => {
+    setBomPath('');
+    setRemoveHItems(false);
+    setRemoveMirror(false);
+    setReady2(false);
+    setReady3(false);
+    setDrawingPath('');
+    setCurrentPhase(1);
+    setStatuses({ phase1: 'idle', phase2: 'idle', phase3: 'idle' });
+    setScore2(' ');
+    setScore3(' ');
+    setComment('Witaj w CreoMate! Wybierz plik BOM i rozpocznij proces.');
+    setExcelButtonColor('#949494');
+  };
+
+  const runPhase = async (phaseKey, url) => {
+    setStatuses(s => ({ ...s, [phaseKey]: 'running' }));
+    let dotCount = 0;
+    setComment('Loading');
+
+    const loadingInterval = setInterval(() => {
+      dotCount = (dotCount + 1) % 4;
+      setComment('Loading' + '.'.repeat(dotCount));
+    }, 500);
+
+    setTimeout(async () => {
+      clearInterval(loadingInterval);
+      try {
+        let res = (phaseKey === 'phase2')
+          ? await fetch(url, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ removeHItems, removeMirror }),
+            })
+          : await fetch(url);
+
+        const data = await res.json();
+
+        if (phaseKey === 'phase1' && data.ready) {
+          setComment('BOM został poprawnie przetworzony i zapisany w Excelu.');
+          setExcelButtonColor('#0066ff');
+        } else if (phaseKey === 'phase2' && data.message) {
+          setScore2(data.message);
+          setComment(
+            data.ready
+              ? 'Etap 2 zakończony pomyślnie. Możesz przejść do etapu 3.'
+              : 'Popraw Excel, aby kontynuować.'
+          );
+        } else if (phaseKey === 'phase3' && data.message) {
+          setScore3(data.message);
+          setComment(
+            data.ready
+              ? 'Etap 3 zakończony pomyślnie. Wygeneruj Excel do działu zakupów.'
+              : 'Sprawdź rysunki, aby kontynuować.'
+          );
+        }
+
+        setStatuses(s => ({ ...s, [phaseKey]: data.ready ? 'done' : 'running' }));
+        if (data.ready) setCurrentPhase(p => (p < 5 ? p + 1 : p));
+      } catch (err) {
+        setStatuses(s => ({ ...s, [phaseKey]: 'idle' }));
+        alert(`Error running ${phaseKey}: ${err.message}`);
+      }
+    }, 1700);
+  };
+
+  const isExcelOpen = async () => {
+    try {
+      const res = await fetch('http://127.0.0.1:8000/isExcelOpen');
+      const text = await res.text();
+      const data = JSON.parse(text);
+      return data.open;
+    } catch (err) {
+      console.error('Failed to check Excel status:', err);
+      return false;
+    }
+  };
+
+  const handleStart = async () => {
+    let excelOpen = false;
+    if (currentPhase > 1) {
+      excelOpen = await isExcelOpen();
+    }
+
+    if (excelOpen) {
+      setComment('Excel jest już otwarty. Zamknij go!');
+      return;
+    }
+
+    if (drawingPath === '' && currentPhase === 3) {
+      setComment('Wybierz folder z rysunkami!');
+      return;
+    }
+
+    if (bomPath === '' && currentPhase === 1) {
+      setComment('Wybierz plik BOM!');
+      return;
+    }
+
+    const phaseUrls = {
+      1: 'http://127.0.0.1:8000/run-phase1',
+      2: 'http://127.0.0.1:8000/run-phase2',
+      3: 'http://127.0.0.1:8000/run-phase3',
+      4: 'http://127.0.0.1:8000/run-phase4',
+      10: 'http://127.0.0.1:8000/run-phase10',
+    };
+
+    if (currentPhase >= 1 && currentPhase <= 4) {
+      await runPhase(`phase${currentPhase}`, phaseUrls[currentPhase]);
+    } else if (currentPhase === 5) {
+      resetLocal();
+    } else {
+      alert('All phases complete!');
+    }
+  };
+
+  const openExcel = async () => {
+    try {
+      const res = await fetch('http://127.0.0.1:8000/openExcel');
+      const data = await res.json();
+      if (data.ready) console.log('Excel opened successfully.');
+    } catch (err) {
+      console.error('Failed to open Excel:', err);
+    }
+  };
+
+  const openExcelPurchases = async () => {
+    try {
+      const res = await fetch('http://127.0.0.1:8000/openExcelPurchases');
+      const data = await res.json();
+      if (data.ready) console.log('Purchase Excel opened.');
+    } catch (err) {
+      console.error('Failed to open Excel:', err);
+    }
+  };
+
+  const getButtonLabel = () => {
+    if (currentPhase <= 3) return `Start Etap ${currentPhase}`;
+    if (currentPhase === 4) return 'Wygeneruj Gotowy Excel';
+    if (currentPhase === 5) return 'Nowy BOM';
+    return 'Proces zakończony';
+  };
 
   
 


### PR DESCRIPTION
## Summary
- localize App's helper logic inside Page1
- remove shared helpers from App
- adjust Page2 to drop unused prop

## Testing
- `npm test -- --watchAll=false` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684ac9d2da44832787ea13f85669c8c9